### PR TITLE
Add capabilities to produce legal extended markdown tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ markdownTable(data).setParams(...):
     row_sep (str): Row separation strategy with the following options:
             'always'        Separate each row
             'topbottom'     Insert row separator above header and below the last row
+            'markdown'      Single header/body separator formated as valid markdown
             'None'          No row separation
     padding_width (int):    Extra padding to all table cells
     padding_weight (str):   Padding strategy. The following values are accepted:
@@ -38,6 +39,7 @@ markdownTable(data).setParams(...):
     newline_char (str):     Custom character to be used for indicating a newline. Default is '\n'
     float_rounding (int):   Round down float values to a number decimal places.
                             Default is 2, but can also be set to 'None' to not round down.
+    quote(bool):            If true (default) surrounds the table with markdown block code quote
 ```
 
 ## Using it with a dataframe
@@ -78,6 +80,26 @@ markdownTable(df.to_dict(orient='records')).getMarkdown()
 |Vrij Zwemmen|13:15-14:15|Sat 12.12|18/18|
 +----------------------------------------+
 ```
+
+```markdownTable(data).setParams(row_sep = 'markdown').getMarkdown()```
+```
+|    title   |    time   |   date  |seats|
+|------------|-----------|---------|-----|
+|Vrij Zwemmen|21:30-23:00|Wed 09.12|24/24|
+|Vrij Zwemmen|12:00-13:00|Thu 10.12|18/18|
+|Vrij zwemmen| 7:30-8:30 |Fri 11.12|18/18|
+|Vrij Zwemmen|13:15-14:15|Sat 12.12|18/18|
+```
+
+```markdownTable(data).setParams(row_sep = 'markdown', quote = False).getMarkdown()```
+
+|    title   |    time   |   date  |seats|
+|------------|-----------|---------|-----|
+|Vrij Zwemmen|21:30-23:00|Wed 09.12|24/24|
+|Vrij Zwemmen|12:00-13:00|Thu 10.12|18/18|
+|Vrij zwemmen| 7:30-8:30 |Fri 11.12|18/18|
+|Vrij Zwemmen|13:15-14:15|Sat 12.12|18/18|
+
 
 ```markdownTable(data).setParams(row_sep = 'topbottom', padding_width = 5, padding_weight='left').getMarkdown()```
 ```

--- a/markdownTable/__init__.py
+++ b/markdownTable/__init__.py
@@ -115,7 +115,7 @@ class markdownTable():
 
     def getHeader(self):
         header = ''
-        if self.row_sep == 'topbottom' or 'always':
+        if self.row_sep in ('topbottom', 'always'):
             header += self.newline_char + self.var_row_sep_last + self.newline_char
         for key in self.data[0].keys():
             margin = self.var_padding[key]-len(key)
@@ -124,6 +124,8 @@ class markdownTable():
         header += '|' + self.newline_char
         if self.row_sep == 'always':
             header += self.var_row_sep + self.newline_char
+        if self.row_sep == 'markdown':
+            header += self.var_row_sep.replace('+', '|') + self.newline_char
         return header
 
     def getBody(self):

--- a/markdownTable/__init__.py
+++ b/markdownTable/__init__.py
@@ -44,16 +44,18 @@ class markdownTable():
         self.padding_char = ' '
         self.newline_char = '\n'
         self.float_rounding = 2
+        self.quote = True
         self.updateMetaParams()
         return
 
-    def setParams(self, row_sep='always', padding_width=0, padding_weight='centerleft', padding_char=' ', newline_char='\n', float_rounding=2):
+    def setParams(self, row_sep='always', padding_width=0, padding_weight='centerleft', padding_char=' ', newline_char='\n', float_rounding=2, quote=True):
         self.row_sep = row_sep
         self.padding_width = padding_width
         self.padding_weight = padding_weight
         self.padding_char = padding_char
         self.newline_char = newline_char
         self.float_rounding = float_rounding
+        self.quote = quote
         self.updateMetaParams()
         return self
 
@@ -111,7 +113,11 @@ class markdownTable():
         return right
 
     def getMarkdown(self):
-        return '```'+self.getHeader()+self.getBody()+'```'
+        data = self.getHeader()+self.getBody()
+        if self.quote:
+            return '```'+data+'```'
+        else:
+            return data
 
     def getHeader(self):
         header = ''

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -49,6 +49,12 @@ def test_formatting_markdown():
     assert mt == res
 
 
+def test_formatting_markdown_noquote():
+    mt = markdownTable(formatting_data).setParams(row_sep='markdown', quote=False).getMarkdown()
+    res = '|    title   |    time   |   date  |seats|\n|------------|-----------|---------|-----|\n|Vrij Zwemmen|21:30-23:00|Wed 09.12|24/24|\n|Vrij Zwemmen|12:00-13:00|Thu 10.12|18/18|\n|Vrij Zwemmen| 7:30-8:30 |Fri 11.12|18/18|\n|Vrij Zwemmen|13:15-14:15|Sat 12.12|18/18|'
+    assert mt == res
+
+
 def test_formatting_right():
     mt = markdownTable(formatting_data).setParams(row_sep='topbottom', padding_weight='right').getMarkdown()
     res = '```\n+----------------------------------------+\n|title       |time       |date     |seats|\n|Vrij Zwemmen|21:30-23:00|Wed 09.12|24/24|\n|Vrij Zwemmen|12:00-13:00|Thu 10.12|18/18|\n|Vrij Zwemmen|7:30-8:30  |Fri 11.12|18/18|\n|Vrij Zwemmen|13:15-14:15|Sat 12.12|18/18|\n+----------------------------------------+```'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -43,6 +43,12 @@ def test_formatting_topbottom():
     assert mt == res
 
 
+def test_formatting_markdown():
+    mt = markdownTable(formatting_data).setParams(row_sep='markdown').getMarkdown()
+    res = '```|    title   |    time   |   date  |seats|\n|------------|-----------|---------|-----|\n|Vrij Zwemmen|21:30-23:00|Wed 09.12|24/24|\n|Vrij Zwemmen|12:00-13:00|Thu 10.12|18/18|\n|Vrij Zwemmen| 7:30-8:30 |Fri 11.12|18/18|\n|Vrij Zwemmen|13:15-14:15|Sat 12.12|18/18|```'
+    assert mt == res
+
+
 def test_formatting_right():
     mt = markdownTable(formatting_data).setParams(row_sep='topbottom', padding_weight='right').getMarkdown()
     res = '```\n+----------------------------------------+\n|title       |time       |date     |seats|\n|Vrij Zwemmen|21:30-23:00|Wed 09.12|24/24|\n|Vrij Zwemmen|12:00-13:00|Thu 10.12|18/18|\n|Vrij Zwemmen|7:30-8:30  |Fri 11.12|18/18|\n|Vrij Zwemmen|13:15-14:15|Sat 12.12|18/18|\n+----------------------------------------+```'


### PR DESCRIPTION
This adds the ability to produce legal extended markdown syntax tables - https://www.markdownguide.org/extended-syntax/#tables - by:-

- adding a `rowsep="markdown"` option that changes the rowsep markup
- adding a `quote=False` option that removes the surrounding ``` quoting ```
- updated README to match

Tests also included.

This is a minimum markdown implementation - no left/centr/right justification etc
